### PR TITLE
feat(accounts): paginate lookupBookmarkedStatuses

### DIFF
--- a/lib/src/service/v1/accounts/accounts_v1_service.dart
+++ b/lib/src/service/v1/accounts/accounts_v1_service.dart
@@ -1186,6 +1186,12 @@ abstract class AccountsV1Service {
   /// - [limit]: Maximum number of results to return. Defaults to 20 statuses.
   ///            Max 40 statuses.
   ///
+  /// - [maxId]: Return results older than this ID.
+  ///
+  /// - [minId]: Return results immediately newer than this ID.
+  ///
+  /// - [sinceId]: Return results newer than this ID.
+  ///
   /// ## Endpoint Url
   ///
   /// - GET /api/v1/bookmarks HTTP/1.1
@@ -1203,6 +1209,9 @@ abstract class AccountsV1Service {
   /// - https://docs.joinmastodon.org/methods/bookmarks/#get
   Future<MastodonResponse<List<Status>>> lookupBookmarkedStatuses({
     int? limit,
+    String? maxId,
+    String? minId,
+    String? sinceId,
   });
 
   /// View domains the user has blocked.
@@ -2018,6 +2027,9 @@ class _AccountsV1Service extends BaseService implements AccountsV1Service {
   @override
   Future<MastodonResponse<List<Status>>> lookupBookmarkedStatuses({
     int? limit,
+    String? maxId,
+    String? minId,
+    String? sinceId,
   }) async =>
       super.transformMultiDataResponse(
         await super.get(
@@ -2025,6 +2037,9 @@ class _AccountsV1Service extends BaseService implements AccountsV1Service {
           '/api/v1/bookmarks',
           queryParameters: {
             'limit': limit,
+            if (maxId != null) 'max_id': maxId,
+            if (minId != null) 'min_id': minId,
+            if (sinceId != null) 'since_id': sinceId,
           },
         ),
         dataBuilder: Status.fromJson,

--- a/test/src/service/v1/accounts/accounts_v1_service_test.dart
+++ b/test/src/service/v1/accounts/accounts_v1_service_test.dart
@@ -2657,6 +2657,34 @@ void main() {
         ),
       );
     });
+
+    test('forwards pagination cursors as query parameters', () async {
+      final accountsService = AccountsV1Service(
+        instance: 'test',
+        context: context.buildGetStub(
+          'test',
+          UserContext.oauth2Only,
+          '/api/v1/bookmarks',
+          'test/src/service/v1/accounts/data/lookup_bookmarked_statuses.json',
+          {
+            'limit': '40',
+            'max_id': '111111',
+            'min_id': '222222',
+            'since_id': '333333',
+          },
+        ),
+      );
+
+      final response = await accountsService.lookupBookmarkedStatuses(
+        limit: 40,
+        maxId: '111111',
+        minId: '222222',
+        sinceId: '333333',
+      );
+
+      expect(response, isA<MastodonResponse>());
+      expect(response.data, isA<List<Status>>());
+    });
   });
 
   group('.lookupBlockedDomains', () {


### PR DESCRIPTION
## Summary

Adds `maxId` / `minId` / `sinceId` parameters to `AccountsV1Service.lookupBookmarkedStatuses` (and its `_AccountsV1Service` impl) so callers can paginate `GET /api/v1/bookmarks` via the standard Mastodon Link-header cursor flow.

Without these params, callers parse `rel=\"next\"` out of the response Link header and have nowhere to feed the resulting `max_id` back into the SDK — bookmarks are effectively capped at the first page (≤40 statuses).

The shape matches the existing pagination contract on:
- `lookupFollowers`
- `lookupFollowings`

…and aligns with the Mastodon API guidelines: https://docs.joinmastodon.org/api/guidelines/#pagination
And the bookmarks endpoint docs: https://docs.joinmastodon.org/methods/bookmarks/

## Changes

- \`lookupBookmarkedStatuses\` interface: 3 new optional named params (\`maxId\`, \`minId\`, \`sinceId\`).
- \`_AccountsV1Service\` impl: forward each non-null param as the appropriate query param (\`max_id\` / \`min_id\` / \`since_id\`).
- Test: new \"forwards pagination cursors as query parameters\" case under the existing \`.lookupBookmarkedStatuses\` group.

Diff is +43 lines, additive, fully backward-compatible — existing callers passing only \`limit:\` are unaffected.

## Test plan

- [x] \`dart analyze\` clean on touched files.
- [ ] CI \`dart test test/src/service/v1/accounts/accounts_v1_service_test.dart\` green.
- [ ] Manual smoke against a real Mastodon instance: \`limit: 40, maxId: <id-from-prev-link>\` → second page of bookmarks returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)